### PR TITLE
Scoring System Butterfly

### DIFF
--- a/generate_resource_scores.pl
+++ b/generate_resource_scores.pl
@@ -553,20 +553,24 @@ sub calculate_internal_score {
     }
     if ( $very_good == 1 ) {
         return 5;
+        say "\t\tScore: 5" if $verbose;
     }
     elsif ( $good == 1 ) {
+        say "\t\tScore: 4" if $verbose;
         return 4;
     }
     elsif ( $acceptable == 1 ) {
+        say "\t\tScore: 3" if $verbose;
         return 3;
     }
 
     $poor = score_is('poor', $type, $resource);
     say "\tPoor? $poor" if $verbose;
     if ( $poor == 1 ) {
+        say "\t\tScore: 2" if $verbose;
         return 2;
     }
-    say "\tVery Poor." if $verbose;
+    say "\t\tScore: 1" if $verbose;
     return 1;
 }
 

--- a/generate_resource_scores.pl
+++ b/generate_resource_scores.pl
@@ -189,13 +189,21 @@ sub score_publication {
 
     my $resource = $g->get("$resource_uri") or die " Failed to retrieve resource: $resource_uri";
 
-    say "Resource: $resource_uri" if $verbose;
+    say "Resource: $resource_uri Type: $type" if $verbose;
     my $score = calculate_internal_score( $type, $resource);
 
-    my $connections->{contributors} = score_contributors(
+    # Only publication types get contributors. Person & Org return false readings.
+    my $connections->{contributors} = {};
+    if ( grep { $type eq $_ } qw/person organization/ ) {
+        say "No contribs on Persons and Orgs." if $verbose;
+    }
+    else {
+        $connections->{contributors} = score_contributors(
                             contributors => $resource->{contributors},
                             depth        => $depth,
                          );
+    }
+
     # Only some publication types get references
     $connections->{references} = {};
     if ( grep { $type eq $_ } qw/report chapter figure finding table webpage book dataset journal/ ) {

--- a/generate_resource_scores.pl
+++ b/generate_resource_scores.pl
@@ -579,9 +579,8 @@ sub score_is {
 
     # there can be multiple ways to get to the score
     for my $qualifying_grades ( @{ $RUBRIC->{$type}->{$quality} } ) {
+        return -1 if $qualifying_grades->{required} == -1;
         my @keys_to_look_for = @{ $qualifying_grades->{fields} };
-        my $required_num_keys = $qualifying_grades->{required};
-        return 1 if $required_num_keys == -1;
         my $count = 0;
         for my $key ( @keys_to_look_for ) {
             if ( $key =~ /:/ ) {
@@ -590,7 +589,7 @@ sub score_is {
             elsif ( exists $resource->{$key} && $resource->{$key} &&  $resource->{$key} ne '') {
                 $count++;
             }
-            return 1 if $count == $required_num_keys;
+            return 1 if $count == $qualifying_grades->{required};
         }
     }
 
@@ -626,8 +625,8 @@ sub score_subkey {
             return 1;
         }
     }
-    # files and figures have an array, and one of those has a key
-    elsif ( $keys[0] eq 'files' || $keys[0] eq 'figures' ) {
+    # files and figures have an array, and one of those has a key.
+    elsif ( $keys[0] eq 'files' || $keys[0] eq 'figures' || $keys[0] eq 'contributors' ) {
         if (
           exists $resource->{$keys[0]}->[$keys[1]]->{$keys[2]}
           && $resource->{$keys[0]}->[$keys[1]]->{$keys[2]}
@@ -635,6 +634,7 @@ sub score_subkey {
             return 1;
         }
     }
+
     return 0;
 }
 

--- a/generate_resource_scores.pl
+++ b/generate_resource_scores.pl
@@ -189,6 +189,7 @@ sub score_publication {
 
     my $resource = $g->get("$resource_uri") or die " Failed to retrieve resource: $resource_uri";
 
+    say "Resource: $resource_uri" if $verbose;
     my $score = calculate_internal_score( $type, $resource);
 
     my $connections->{contributors} = score_contributors(
@@ -314,6 +315,7 @@ sub score_entity {
 
     my $resource = $g->get("$resource_uri") or die " Failed to retrieve resource: $resource_uri";
     print "\t";
+    say "Resource: $resource_uri" if $verbose;
     my $score = calculate_internal_score( $type, $resource);
 
     my $components = score_components(
@@ -374,6 +376,7 @@ sub score_reference {
     my $reference = $args{reference};
     my $depth     = $args{depth};
 
+    say "Resource: /reference/$reference->{identifier}" if $verbose;
     my $score = calculate_internal_score( 'reference', $reference );
 
     # does child pub exist?
@@ -530,10 +533,14 @@ sub calculate_internal_score {
     print "." if $progress;
     my ( $very_poor, $poor, $acceptable, $good, $very_good ) = 0;
     $acceptable = score_is('acceptable', $type, $resource);
+    #say Dumper $resource if $verbose;
+    say "\tAcceptable? $acceptable" if $verbose;
     if ( $acceptable ) {
         $good = score_is('good', $type, $resource);
+        say "\tGood? $good" if $verbose;
         if ( $good ) {
             $very_good = score_is('very_good', $type, $resource);
+            say "\tVery Good? $very_good" if $verbose;
         }
     }
     if ( $very_good == 1 ) {
@@ -546,9 +553,12 @@ sub calculate_internal_score {
         return 3;
     }
 
-    if ( score_is('poor', $type, $resource) ) {
+    $poor = score_is('poor', $type, $resource);
+    say "\tPoor? $poor" if $verbose;
+    if ( $poor == 1 ) {
         return 2;
     }
+    say "\tVery Poor." if $verbose;
     return 1;
 }
 

--- a/generate_resource_scores.pl
+++ b/generate_resource_scores.pl
@@ -43,9 +43,10 @@ File containing the Internal item scores. Default scores/internal_score.yaml
 
 File containing the component relationships. Default config/components.yaml
 
-=item B<--depth>
+=item B<--depth_references>
 
-How many references deep to process. Default 1.
+When encountering a reference, we will look at the child publication and all of
+its componenets and contributors this many times. Default 0.
 
 =item B<--verbose>
 
@@ -73,7 +74,7 @@ looking at dev, go deeper and normal and use custom scores.
   --resouce report/usgcrp-climate-human-health-assessment-2016/chapter/extreme-events \
   --tree_file ./hhs2016_ch_extreme_tree.yaml \
   --url https://data-dev.globalchange.gov \
-  --depth 3 \
+  --depth_references 1 \
   --connection_score /tmp/new_scores.yml \
   --internal_score /tmp/new_inner_scores.yml \
   --components /tmp/comps.yml
@@ -96,7 +97,7 @@ use v5.14;
 
 # local $YAML::Indent = 2;
 
-my $MAX_DEPTH = 1;
+my $MAX_DEPTH = 0;
 my $RUBRIC;
 my $COMPONENTS;
 my $URL = "https://data.globalchange.gov";
@@ -110,7 +111,7 @@ GetOptions(
   'connection_score=s'  => \$connection_score,
   'internal_score=s'    => \$internal_score,
   'components=s'        => \$components_map,
-  'depth=i'             => \$MAX_DEPTH,
+  'depth_references=i'  => \$MAX_DEPTH,
   'verbose!'            => \(my $verbose),
   'progress!'           => \(my $progress),
   'help|?'              => sub { pod2usage(verbose => 2) },
@@ -145,7 +146,7 @@ Evaluating Provenance
     internal scores file   : $internal_score
     connection scores file : $connection_score
     components file        : $components_map
-    depth                  : $MAX_DEPTH
+    depth_references       : $MAX_DEPTH
 
 END
     say $greeting if $verbose;

--- a/generate_resource_scores.pl
+++ b/generate_resource_scores.pl
@@ -64,14 +64,14 @@ Progress monitor printed to screen, to show the script is making progress.
 Score the nca3 report
 
 ./generate_resource_scores.pl \
-  --resouce /report/nca3 \
+  --resource /report/nca3 \
   --tree_file ./nca3_tree.yaml
 
 Score the chapter extreme-events from the Report Climate Human Health Assessment 2016,
 looking at dev, go deeper and normal and use custom scores.
 
 ./generate_resource_scores.pl \
-  --resouce report/usgcrp-climate-human-health-assessment-2016/chapter/extreme-events \
+  --resource report/usgcrp-climate-human-health-assessment-2016/chapter/extreme-events \
   --tree_file ./hhs2016_ch_extreme_tree.yaml \
   --url https://data-dev.globalchange.gov \
   --depth_references 1 \

--- a/generate_resource_scores.pl
+++ b/generate_resource_scores.pl
@@ -240,7 +240,7 @@ sub score_contributors {
             contributor => $contrib,
             depth       => $depth,
         );
-        $contributors_scored->{$contrib->{uri}} = $contrib_score;
+        $contributors_scored->{"/contributor/$contrib->{id}"} = $contrib_score;
     }
     return $contributors_scored;
 }
@@ -260,6 +260,7 @@ sub score_contributor {
     my $depth       = $args{depth};
     my $contributor = $args{contributor};
 
+    say "Resource: /contributor/$contributor->{id}" if $verbose;
     my $score = calculate_internal_score( 'contributor', $contributor);
 
     my $person = $contributor->{person_uri}
@@ -353,7 +354,7 @@ sub score_references {
             reference => $ref,
             depth     => $depth,
         );
-        $references_scored->{$ref->{uri}} = $ref_score;
+        $references_scored->{"/reference/$ref->{identifier}/"} = $ref_score;
     }
     return $references_scored;
 }

--- a/generate_resource_scores.pl
+++ b/generate_resource_scores.pl
@@ -46,7 +46,7 @@ File containing the component relationships. Default config/components.yaml
 =item B<--depth_references>
 
 When encountering a reference, we will look at the child publication and all of
-its componenets and contributors this many times. Default 0.
+its components and contributors this many times. Default 0.
 
 =item B<--verbose>
 

--- a/scores/connection_score.yaml
+++ b/scores/connection_score.yaml
@@ -7,26 +7,26 @@ contributor:
   acceptable:
     - 
       fields:
-        - person_uri
+        - person_id
         - role_type_identifier
       required: 2
     - 
       fields:
-        - organization_uri
+        - organization_identifier
         - role_type_identifier
       required: 2
   good:
     - 
       fields:
-        - person_uri
-        - organization_uri
+        - person_id
+        - organization_identifier
         - role_type_identifier
       required: 3
   poor:
     - 
       fields:
-        - person_uri
-        - organization_uri
+        - person_id
+        - organization_identifier
       required: 1
   very_good:
     - 

--- a/scores/connection_score.yaml
+++ b/scores/connection_score.yaml
@@ -7,26 +7,26 @@ contributor:
   acceptable:
     - 
       fields:
-        - person_id
+        - person_uri
         - role_type_identifier
       required: 2
     - 
       fields:
-        - organization_identifier
+        - organization_uri
         - role_type_identifier
       required: 2
   good:
     - 
       fields:
-        - person_id
-        - organization_identifier
+        - person_uri
+        - organization_uri
         - role_type_identifier
       required: 3
   poor:
     - 
       fields:
-        - person_id
-        - organization_identifier
+        - person_uri
+        - organization_uri
       required: 1
   very_good:
     - 

--- a/scores/connection_score.yaml
+++ b/scores/connection_score.yaml
@@ -3,41 +3,40 @@
 # If acceptable, good? very good?
 # If multiple exist, any is enough.
 --- 
-contributor: 
-  acceptable: 
+contributor:
+  acceptable:
     - 
-      fields: 
+      fields:
         - person_uri
-        - reference_identifier # Not currently available from API
+        - role_type_identifier
       required: 2
     - 
-      fields: 
+      fields:
         - organization_uri
-        - reference_identifier # Not currently available from API
+        - role_type_identifier
       required: 2
-  good: 
+  good:
     - 
-      fields: 
+      fields:
         - person_uri
         - organization_uri
-        - reference_identifier # Not currently available from API
+        - role_type_identifier
       required: 3
-  poor: 
+  poor:
     - 
-      fields: 
+      fields:
         - person_uri
         - organization_uri
       required: 1
-  very_good: 
+  very_good:
     - 
       fields: []
       required: -1
-  very_poor: 
+  very_poor:
     - 
-      fields: 
+      fields:
         - id
-        - role_type_identifer
-      required: 2
+      required: 1
 reference: 
   acceptable: 
     - 

--- a/scores/internal_score.yaml
+++ b/scores/internal_score.yaml
@@ -556,10 +556,8 @@ organization:
 person: 
   acceptable: 
     - 
-      fields: 
-        - url
-        - orcid
-      required: 1
+      fields: []
+      required: -1
   good: 
     - 
       fields: 

--- a/scores/internal_score.yaml
+++ b/scores/internal_score.yaml
@@ -411,36 +411,92 @@ instrument:
         - identifier
         - name
       required: 2
-journal: 
-  acceptable: 
+journal:
+  acceptable:
     - 
-      fields: 
-        - url
+      fields:
+        - title
         - print_issn
-        - online_issn
-      required: 1
-  good: 
+      required: 2
     - 
-      fields: 
+      fields:
+        - title
+        - online_issn
+      required: 2
+    - 
+      fields:
+        - title
+        - url
+      required: 2
+  good:
+    - 
+      fields:
+        - title
+        - url
+        - online_issn
+      required: 3
+    - 
+      fields:
         - title
         - url
         - print_issn
+      required: 3
+    - 
+      fields:
+        - title
+        - "contributors:0:organization_uri"
+        - print_issn
+      required: 3
+    - 
+      fields:
+        - title
+        - "contributors:0:organization_uri"
         - online_issn
+      required: 3
+    - 
+      fields:
+        - title
+        - "contributors:0:organization_uri"
+        - url
       required: 3
   poor: 
     - 
-      fields: 
+      fields:
         - title
-      required: 1
-  very_good: 
+        - country
+      required: 2
     - 
-      fields: 
+      fields:
+        - title
+        - "contributors:0:organization_uri"
+      required: 2
+    - 
+      fields:
+        - print_issn
+      required: 1
+    - 
+      fields:
+        - online_issn
+      required: 1
+    - 
+      fields:
+        - url
+      required: 1
+  very_good:
+    - 
+      fields:
         - notes
         - country
       required: 1
-  very_poor: 
     - 
-      fields: 
+      fields:
+        - print_issn
+        - online_issn
+        - url
+      required: 3
+  very_poor:
+    - 
+      fields:
         - identifier
       required: 1
 model: 

--- a/scores/internal_score.yaml
+++ b/scores/internal_score.yaml
@@ -389,8 +389,9 @@ image:
 instrument: 
   acceptable: 
     - 
-      fields: []
-      required: -1
+      fields:
+        - description_attribution
+      required: 1
   good: 
     - 
       fields: 
@@ -486,8 +487,10 @@ model_run:
       required: 1
   good: 
     - 
-      fields: []
-      required: -1
+      fields:
+        - sequence_description
+        - time_resolution
+      required: 1
   poor: 
     - 
       fields: []

--- a/scores/internal_score.yaml
+++ b/scores/internal_score.yaml
@@ -553,8 +553,10 @@ organization:
 person: 
   acceptable: 
     - 
-      fields: []
-      required: -1
+      fields: 
+        - url
+        - orcid
+      required: 1
   good: 
     - 
       fields: 

--- a/scores/internal_score.yaml
+++ b/scores/internal_score.yaml
@@ -389,9 +389,8 @@ image:
 instrument: 
   acceptable: 
     - 
-      fields:
-        - description_attribution
-      required: 1
+      fields: []
+      required: -1
   good: 
     - 
       fields: 
@@ -487,10 +486,8 @@ model_run:
       required: 1
   good: 
     - 
-      fields:
-        - sequence_description
-        - time_resolution
-      required: 1
+      fields: []
+      required: -1
   poor: 
     - 
       fields: []


### PR DESCRIPTION
A series of improvements and revisions for the metrics system. 

## Scoring Changes

**Contributor**  
We decided that you don't need a reference when assessing that a person/org contributed to a publication.

Changes:
  - Contributor Acceptable: 
    - Old: `person + reference` OR `org + reference`
    - New: `Person + Role Type` OR `Org  + Role Type.`
  - Contributor Good: 
    - Old: `Person + Org + Reference`
    - New: `Person + Org + Role Type.`


## Script FIxes

  - Scores no longer stick on skipped score levels.
    - Persons, Instruments, and Model Runs may have had inflated scores prior.
  - Contributor subkeys now properly handled
    - Allows a Person score of 2. 
    - Would have been invisible due to sticky skipped bug for person score of 3.
  - Persons & Organizations no longer think they have "Contributors"
    - Contributors under these objects are _very different_ than the one under a publication.
    - Only in effect when running on a Person or Org directly.
  - Contributor & sub-Reference component URIs specified in a safer manner. 

## Misc Changes

  - Better verbose output for debugging
  